### PR TITLE
Improve badge visibility with modal preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,11 +46,11 @@
                 </div>
             </div>
             <div class="badge-container">
-                <img src="icons/badge-5-correct.png" title="5 correct answers in a row" alt="5 correct answers badge">
-                <img src="icons/badge-10-correct.png" title="10 correct answers in a row" alt="10 correct answers badge">
-                <img src="icons/badge-20-correct.png" title="20 correct answers in a row" alt="20 correct answers badge">
-                <img src="icons/badge-level-2.png" title="Reached level 2" alt="Level 2 badge">
-                <img src="icons/badge-level-3.png" title="Reached level 3" alt="Level 3 badge">
+                <img src="icons/badge-5-correct.png" title="5 correct answers in a row" alt="5 correct answers badge" onclick="showBadgeModal('5 correct answers in a row')">
+                <img src="icons/badge-10-correct.png" title="10 correct answers in a row" alt="10 correct answers badge" onclick="showBadgeModal('10 correct answers in a row')">
+                <img src="icons/badge-20-correct.png" title="20 correct answers in a row" alt="20 correct answers badge" onclick="showBadgeModal('20 correct answers in a row')">
+                <img src="icons/badge-level-2.png" title="Reached level 2" alt="Level 2 badge" onclick="showBadgeModal('Reached level 2')">
+                <img src="icons/badge-level-3.png" title="Reached level 3" alt="Level 3 badge" onclick="showBadgeModal('Reached level 3')">
             </div>
         </header>
         

--- a/js/script.js
+++ b/js/script.js
@@ -289,6 +289,7 @@ class MusicFlashcards {
             img.src = `icons/${filename}.png`;
             img.title = badge;
             img.alt = `${badge} badge`;
+            img.onclick = () => showBadgeModal(badge); // P35cc
             badgeContainer.appendChild(img);
         });
     }
@@ -480,13 +481,15 @@ window.showBadgeModal = function(badgeName) {
         modal.classList.add('visible');
     }, 10);
     
-    // Auto-dismiss after 3 seconds
-    setTimeout(() => {
-        modal.classList.remove('visible');
-        setTimeout(() => {
-            modal.style.display = 'none';
-        }, 500);
-    }, 3000);
+    // Add event listener to close modal when clicking outside the modal content
+    modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            modal.classList.remove('visible');
+            setTimeout(() => {
+                modal.style.display = 'none';
+            }, 500);
+        }
+    });
 };
 
 // Initialize the app when the DOM is loaded


### PR DESCRIPTION
Add functionality to display a larger preview of badges when clicked.

* **index.html**
  - Add `onclick` event listener to badge images to call `showBadgeModal` function with the badge description.

* **js/script.js**
  - Update `showBadgeModal` function to remove auto-dismiss after 3 seconds.
  - Add event listener to close badge modal when clicking outside the modal content.

