### PR TITLE
Fix end game to trigger at the end of level 3

### DIFF
--- a/js/noteData.js
+++ b/js/noteData.js
@@ -238,7 +238,13 @@ class NoteData {
     // Add a method to check if the user has reached the last level
     isLastLevel() {
         const lastLevel = 3; // Define the last level
-        return this.userLevel >= lastLevel;
+        return this.userLevel > lastLevel;
+    }
+
+    // Add a method to check if the user is at the end of a specific level
+    isEndOfLevel(level) {
+        const pointsNeeded = level * 100;
+        return this.experiencePoints >= pointsNeeded;
     }
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -461,8 +461,8 @@ window.showLevelUpModal = function(oldLevel, newLevel, remainingXP, newPointsNee
         }, 500);
     }, { once: true }); // Use once to prevent multiple event listeners
 
-    // Check if the last level is reached and end the game if true
-    if (noteData.isLastLevel()) {
+    // Check if the user is at the end of level 3 and end the game if true
+    if (noteData.isEndOfLevel(3)) {
         endGame();
     }
 };


### PR DESCRIPTION
Update the end of the game to trigger at the end of level 3 instead of the beginning.

* Modify `isLastLevel` method in `js/noteData.js` to return true only when the user level is greater than the last level.
* Add `isEndOfLevel` method in `js/noteData.js` to check if the user is at the end of a specific level.
* Update `showLevelUpModal` function in `js/script.js` to check if the user is at the end of level 3 and trigger the end game modal.
* Modify `endGame` function in `js/script.js` to be called at the end of level 3 instead of the beginning.

